### PR TITLE
Add props field that contains only the known input props

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Forms are not currently fun to work with in React.  There are a lot of form libr
 
 [Dynamic Fields](http://theadam.github.io/react-inform/examples/dynamic-fields/)
 
-[Integration with react-intl v2](https://jsfiddle.net/d0hypvtz/8/)
+[Integration with react-intl v2](https://jsfiddle.net/theadam/d0hypvtz/21/)
 
 ## Installation
 
@@ -29,7 +29,7 @@ Forms are not currently fun to work with in React.  There are a lot of form libr
 
 ## Guide
 
-Creating a [simple validating form](https://jsfiddle.net/theadam/Lc3nkx7g/3/embedded/result%2Cjs%2Ccss%2Chtml%2Cresources/) is easy with `react-inform`.
+Creating a [simple validating form](https://jsfiddle.net/theadam/Lc3nkx7g/5/embedded/result%2Cjs%2Ccss%2Chtml%2Cresources/) is easy with `react-inform`.
 
 `react-inform` provides a simple decorator.  To that decorator you provide a list of fields in the form, and an optional validate function.  The `validate` function takes in an object where the keys are fieldnames and the values are the values of the fields, and it should return an object where the keys are fieldnames and the values are error strings.
 
@@ -79,15 +79,15 @@ MyForm = form({
 The form function wraps your react component passing a `form` and `fields` property.  The `fields` property can be "plugged into" regular inputs in your render function.  The fields also willl have errors if your validate function returned any!
 
 ```jsx
-<input type="text" placeholder="Username" {...username}/>
+<input type="text" placeholder="Username" {...username.props} />
 <span>{username.error}</span>
-<input type="password" placeholder="Password" {...password}/>
+<input type="password" placeholder="Password" {...password.props} />
 <span>{password.error}</span>
-<input type="password" placeholder="Confirm Password" {...confirmPassword}/>
+<input type="password" placeholder="Confirm Password" {...confirmPassword.props} />
 <span>{confirmPassword.error}</span>
 ```
 
-Simple!  Your form now validates, and keeps track of its state without all the boilerplate!  The complete working example can be seen [here!](https://jsfiddle.net/theadam/Lc3nkx7g/3/embedded/result%2Cjs%2Ccss%2Chtml%2Cresources/)
+Simple!  Your form now validates, and keeps track of its state without all the boilerplate!  The complete working example can be seen [here!](https://jsfiddle.net/theadam/Lc3nkx7g/5/embedded/result%2Cjs%2Ccss%2Chtml%2Cresources/)
 
 ## Api
 
@@ -118,7 +118,17 @@ Form contains some utility functions to affect the wrapping form.  These include
 
 ##### fields
 
-`fields` is a map of the fields you passed in.  Each field has a value, onChange, onFocus, and onBlur property so that they can be passed into regular input components and have them be controlled with `react-inform`.  If there is an error message on a field, the field will also have an error property.
+`fields` is a map of the fields you passed in.  Each field has a value, onChange, and onBlur property so that they can be passed into regular input components and have them be controlled with `react-inform`.  If there is an error message on a field, the field will also have an error property.
+
+All of the props that should be passed to your rendered input component (value, onChange, and onBlur) are also available using the `props` property.  For example:
+
+```jsx
+const { fieldName } = this.props.fields;
+...
+<input type="text" {...fieldName.props} />
+```
+
+This keeps react from complaining about unknown props being passed to input components.  See [this link](https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b) for more details.
 
 ### createValidate(ruleMap)
 

--- a/examples/async-example/index.js
+++ b/examples/async-example/index.js
@@ -13,15 +13,11 @@ import {
 
 alertify.logPosition('top right');
 
-function LabeledInput({ text, error, ...rest }) {
-  let htmlFor = undefined;
-  if (rest.id) {
-    htmlFor = rest.id;
-  }
+function LabeledInput({ text, error, id, props }) {
   return (
     <div>
-      <label htmlFor={htmlFor}>{text}</label>
-      <input placeholder={text} type="text" {...rest} />
+      <label htmlFor={id}>{text}</label>
+      <input id={id} placeholder={text} type="text" {...props} />
       <span className="ui-hint">{error}</span>
     </div>
   );

--- a/examples/basic-example/index.js
+++ b/examples/basic-example/index.js
@@ -16,15 +16,11 @@ import {
 
 alertify.logPosition('top right');
 
-function LabeledInput({ text, error, ...rest }) {
-  let htmlFor = undefined;
-  if (rest.id) {
-    htmlFor = rest.id;
-  }
+function LabeledInput({ text, error, id, props }) {
   return (
     <div>
-      <label htmlFor={htmlFor}>{text}</label>
-      <input placeholder={text} type="text" {...rest} />
+      <label htmlFor={id}>{text}</label>
+      <input id={id} placeholder={text} type="text" {...props} />
       <span className="ui-hint">{error}</span>
     </div>
   );
@@ -63,7 +59,7 @@ class MyForm extends Component {
     return (
       <form onSubmit={e => this.handleSubmit(e)}>
         <label htmlFor="check-b">
-          <input type="checkbox" id="check-b" name="check-b" {...checkbox} />
+          <input type="checkbox" id="check-b" name="check-b" {...checkbox.props} />
           Checkbox Just For Fun
           <span className="ui-hint">{checkbox.error}</span>
         </label>

--- a/examples/basic-example/package.json
+++ b/examples/basic-example/package.json
@@ -37,7 +37,7 @@
     "alertify.js": "^1.0.9",
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
-    "react-textarea-autosize": "^3.3.0",
+    "react-textarea-autosize": "^4.0.5",
     "string-validator": "^1.0.5"
   }
 }

--- a/examples/dynamic-fields/index.js
+++ b/examples/dynamic-fields/index.js
@@ -13,15 +13,11 @@ import {
 
 alertify.logPosition('top right');
 
-function LabeledInput({ text, error, ...rest }) {
-  let htmlFor = undefined;
-  if (rest.id) {
-    htmlFor = rest.id;
-  }
+function LabeledInput({ text, error, id, props }) {
   return (
     <div>
-      <label htmlFor={htmlFor}>{text}</label>
-      <input placeholder={text} type="text" {...rest} />
+      <label htmlFor={id}>{text}</label>
+      <input id={id} placeholder={text} type="text" {...props} />
       <span className="ui-hint">{error}</span>
     </div>
   );

--- a/examples/mation-example/index.js
+++ b/examples/mation-example/index.js
@@ -18,11 +18,17 @@ import { presets } from 'mation';
 
 alertify.logPosition('top right');
 
-function AnimatedInput({ text, error, ...rest }) {
+function AnimatedInput({ text, error, id, props }) {
   return (
     <div>
-      <label htmlFor={rest.id}>{text}</label>
-      <input placeholder={text} style={{ zIndex: 2, position: 'relative' }} type="text" {...rest} />
+      <label htmlFor={id}>{text}</label>
+      <input
+        id={id}
+        placeholder={text}
+        style={{ zIndex: 2, position: 'relative' }}
+        type="text"
+        {...props}
+      />
       <AnimatedUiHint>{error}</AnimatedUiHint>
     </div>
   );
@@ -88,7 +94,7 @@ class MyForm extends Component {
             id="check-b"
             name="check-b"
             style={{ position: 'relative', zIndex: 2 }}
-            {...checkbox}
+            {...checkbox.props}
           />
           Checkbox Just For Fun
           <AnimatedUiHint>{checkbox.error}</AnimatedUiHint>

--- a/examples/mation-example/package.json
+++ b/examples/mation-example/package.json
@@ -39,7 +39,7 @@
     "react": "^15.0.0",
     "react-dom": "^15.0.0",
     "react-mation": "0.0.1",
-    "react-textarea-autosize": "^3.3.0",
+    "react-textarea-autosize": "^4.0.5",
     "string-validator": "^1.0.5"
   }
 }

--- a/src/form.js
+++ b/src/form.js
@@ -111,14 +111,23 @@ export default function form({
       };
     }
 
-    makeField(name) {
-      const { values, errors, touched } = this.state;
+    baseProps(name) {
+      const { values } = this.state;
       return {
         onChange: e => this.handleChange(name, e),
         onBlur: () => this.touch([name]),
         value: values[name] || '',
-        error: touched[name] ? errors[name] : undefined,
         checked: typeof values[name] === 'boolean' ? values[name] : undefined,
+      };
+    }
+
+    makeField(name) {
+      const { errors, touched } = this.state;
+      const baseProps = this.baseProps(name);
+      return {
+        ...baseProps,
+        error: touched[name] ? errors[name] : undefined,
+        props: baseProps,
       };
     }
 

--- a/test/disabledFormSubmit-test.js
+++ b/test/disabledFormSubmit-test.js
@@ -11,7 +11,7 @@ describe('DisabledFormSubmit', () => {
 
   beforeEach(() => {
     props = {
-      foo: 'bar',
+      value: 'bar',
     };
   });
 
@@ -29,7 +29,7 @@ describe('DisabledFormSubmit', () => {
     });
 
     it('passes extra props through', () => {
-      expect(render().find('input').props().foo).to.equal('bar');
+      expect(render().find('input').props().value).to.equal('bar');
     });
 
     it('is enabled', () => {
@@ -51,7 +51,7 @@ describe('DisabledFormSubmit', () => {
     });
 
     it('passes extra props through', () => {
-      expect(render().find('input').props().foo).to.equal('bar');
+      expect(render().find('input').props().value).to.equal('bar');
     });
 
     it('is disabled', () => {

--- a/test/feedbackFormSubmit-test.js
+++ b/test/feedbackFormSubmit-test.js
@@ -12,7 +12,7 @@ describe('FeedbackFormSubmit', () => {
 
   beforeEach(() => {
     props = {
-      foo: 'bar',
+      value: 'bar',
       onClick: spy(),
       onInvalid: spy(),
     };
@@ -33,7 +33,7 @@ describe('FeedbackFormSubmit', () => {
     });
 
     it('passes extra props through', () => {
-      expect(render().find('input').props().foo).to.equal('bar');
+      expect(render().find('input').props().value).to.equal('bar');
     });
 
     describe('when clicked', () => {
@@ -75,7 +75,7 @@ describe('FeedbackFormSubmit', () => {
     });
 
     it('passes extra props through', () => {
-      expect(render().find('input').props().foo).to.equal('bar');
+      expect(render().find('input').props().value).to.equal('bar');
     });
 
     describe('when clicked', () => {

--- a/test/form-combination-test.js
+++ b/test/form-combination-test.js
@@ -5,6 +5,8 @@ import { mount } from 'enzyme';
 
 import form from '../src/form';
 
+const DummyInput = () => null;
+
 // For testing the different combinations of form setup
 describe('combinations', () => {
   const descriptor = {
@@ -23,7 +25,7 @@ describe('combinations', () => {
       },
       form: (
         form(descriptor)(
-          ({ fields }) => <input type="text" {...fields.test} />
+          ({ fields }) => <DummyInput {...fields.test} />
         )
       ),
     }, {
@@ -40,7 +42,7 @@ describe('combinations', () => {
       },
       form: (
         form(descriptor)(
-          ({ fields }) => <input type="text" {...fields.test} />
+          ({ fields }) => <DummyInput type="text" {...fields.test} />
         )
       ),
     }, {
@@ -53,7 +55,7 @@ describe('combinations', () => {
       },
       form: (
         form()(
-          ({ fields }) => <input type="text" {...fields.test} />
+          ({ fields }) => <DummyInput type="text" {...fields.test} />
         )
       ),
     }, {
@@ -71,7 +73,7 @@ describe('combinations', () => {
       },
       form: (
         form()(
-          ({ fields }) => <input type="text" {...fields.test} />
+          ({ fields }) => <DummyInput type="text" {...fields.test} />
         )
       ),
     },
@@ -91,11 +93,11 @@ describe('combinations', () => {
       };
 
       it('has the right starting value', () => {
-        expect(render().find('input').props().value).to.eq('');
+        expect(render().find(DummyInput).props().value).to.eq('');
       });
 
       it('has no errors initially', () => {
-        expect(render().find('input').props().error).to.eq(undefined);
+        expect(render().find(DummyInput).props().error).to.eq(undefined);
       });
 
       it('does not call onChange initially', () => {
@@ -106,16 +108,16 @@ describe('combinations', () => {
       describe('when changed to invalid', () => {
         const changed = () => {
           const comp = render();
-          comp.find('input').props().onChange('invalid');
+          comp.find(DummyInput).props().onChange('invalid');
           return comp;
         };
 
         it('has the right value', () => {
-          expect(changed().find('input').props().value).to.eq('invalid');
+          expect(changed().find(DummyInput).props().value).to.eq('invalid');
         });
 
         it('has no error', () => {
-          expect(changed().find('input').props().error).to.eq(undefined);
+          expect(changed().find(DummyInput).props().error).to.eq(undefined);
         });
 
         it('calls onChange once', () => {
@@ -131,16 +133,16 @@ describe('combinations', () => {
         describe('when blurred', () => {
           const blurred = () => {
             const comp = changed();
-            comp.find('input').props().onBlur();
+            comp.find(DummyInput).props().onBlur();
             return comp;
           };
 
           it('has the right value', () => {
-            expect(blurred().find('input').props().value).to.eq('invalid');
+            expect(blurred().find(DummyInput).props().value).to.eq('invalid');
           });
 
           it('has the error', () => {
-            expect(blurred().find('input').props().error).to.eq('Must be valid');
+            expect(blurred().find(DummyInput).props().error).to.eq('Must be valid');
           });
 
           it('calls onChange once', () => {
@@ -165,7 +167,7 @@ describe('combinations', () => {
             };
 
             it('has an error', () => {
-              expect(invalidate().find('input').props().error).to.eq('Different message');
+              expect(invalidate().find(DummyInput).props().error).to.eq('Different message');
             });
 
             it('does not call onChange again', () => {
@@ -179,16 +181,16 @@ describe('combinations', () => {
       describe('when changed to valid', () => {
         const changed = () => {
           const comp = render();
-          comp.find('input').props().onChange('valid');
+          comp.find(DummyInput).props().onChange('valid');
           return comp;
         };
 
         it('has the right value', () => {
-          expect(changed().find('input').props().value).to.eq('valid');
+          expect(changed().find(DummyInput).props().value).to.eq('valid');
         });
 
         it('has no error', () => {
-          expect(changed().find('input').props().error).to.eq(undefined);
+          expect(changed().find(DummyInput).props().error).to.eq(undefined);
         });
 
         it('calls onChange once', () => {
@@ -204,16 +206,16 @@ describe('combinations', () => {
         describe('when blurred', () => {
           const blurred = () => {
             const comp = changed();
-            comp.find('input').props().onBlur();
+            comp.find(DummyInput).props().onBlur();
             return comp;
           };
 
           it('has the right value', () => {
-            expect(blurred().find('input').props().value).to.eq('valid');
+            expect(blurred().find(DummyInput).props().value).to.eq('valid');
           });
 
           it('has no error', () => {
-            expect(blurred().find('input').props().error).to.eq(undefined);
+            expect(blurred().find(DummyInput).props().error).to.eq(undefined);
           });
 
           it('calls onChange once', () => {
@@ -238,7 +240,7 @@ describe('combinations', () => {
             };
 
             it('has an error', () => {
-              expect(invalidate().find('input').props().error).to.eq('Must not be valid');
+              expect(invalidate().find(DummyInput).props().error).to.eq('Must not be valid');
             });
 
             it('does not call onChange again', () => {
@@ -258,7 +260,7 @@ describe('combinations', () => {
               };
 
               it('removes the error', () => {
-                expect(revalidate().find('input').props().error).to.eq(undefined);
+                expect(revalidate().find(DummyInput).props().error).to.eq(undefined);
               });
 
               it('does not call onChange again', () => {
@@ -271,7 +273,7 @@ describe('combinations', () => {
           describe('when validate and value change to be invalid', () => {
             const invalidate = () => {
               const comp = blurred();
-              comp.find('input').props().onChange('other');
+              comp.find(DummyInput).props().onChange('other');
               const props = {
                 ...comp.props(),
                 validate: ({ test }) => (test === 'other' ? { test: 'suddenly invalid' } : {}),
@@ -281,7 +283,7 @@ describe('combinations', () => {
             };
 
             it('has an error', () => {
-              expect(invalidate().find('input').props().error).to.eq('suddenly invalid');
+              expect(invalidate().find(DummyInput).props().error).to.eq('suddenly invalid');
             });
 
             it('calls onChange again', () => {
@@ -308,11 +310,11 @@ describe('combinations', () => {
         };
 
         it('has the right value', () => {
-          expect(changed().find('input').props().value).to.eq('invalid');
+          expect(changed().find(DummyInput).props().value).to.eq('invalid');
         });
 
         it('has no error', () => {
-          expect(changed().find('input').props().error).to.eq(undefined);
+          expect(changed().find(DummyInput).props().error).to.eq(undefined);
         });
 
         it('does not call onChange', () => {
@@ -323,16 +325,16 @@ describe('combinations', () => {
         describe('when blurred', () => {
           const blurred = () => {
             const comp = changed();
-            comp.find('input').props().onBlur();
+            comp.find(DummyInput).props().onBlur();
             return comp;
           };
 
           it('has the right value', () => {
-            expect(blurred().find('input').props().value).to.eq('invalid');
+            expect(blurred().find(DummyInput).props().value).to.eq('invalid');
           });
 
           it('has the error', () => {
-            expect(blurred().find('input').props().error).to.eq('Must be valid');
+            expect(blurred().find(DummyInput).props().error).to.eq('Must be valid');
           });
 
           it('does not call onChange', () => {
@@ -352,7 +354,7 @@ describe('combinations', () => {
             };
 
             it('has an error', () => {
-              expect(invalidate().find('input').props().error).to.eq('Different message');
+              expect(invalidate().find(DummyInput).props().error).to.eq('Different message');
             });
 
             it('does not call onChange', () => {
@@ -374,11 +376,11 @@ describe('combinations', () => {
         };
 
         it('has the right value', () => {
-          expect(changed().find('input').props().value).to.eq('valid');
+          expect(changed().find(DummyInput).props().value).to.eq('valid');
         });
 
         it('has no error', () => {
-          expect(changed().find('input').props().error).to.eq(undefined);
+          expect(changed().find(DummyInput).props().error).to.eq(undefined);
         });
 
         it('does not call onChange', () => {
@@ -389,16 +391,16 @@ describe('combinations', () => {
         describe('when blurred', () => {
           const blurred = () => {
             const comp = changed();
-            comp.find('input').props().onBlur();
+            comp.find(DummyInput).props().onBlur();
             return comp;
           };
 
           it('has the right value', () => {
-            expect(blurred().find('input').props().value).to.eq('valid');
+            expect(blurred().find(DummyInput).props().value).to.eq('valid');
           });
 
           it('has no error', () => {
-            expect(blurred().find('input').props().error).to.eq(undefined);
+            expect(blurred().find(DummyInput).props().error).to.eq(undefined);
           });
 
           it('does not call onChange', () => {
@@ -418,7 +420,7 @@ describe('combinations', () => {
             };
 
             it('has an error', () => {
-              expect(invalidate().find('input').props().error).to.eq('Must not be valid');
+              expect(invalidate().find(DummyInput).props().error).to.eq('Must not be valid');
             });
 
             it('does not call onChange', () => {
@@ -438,7 +440,7 @@ describe('combinations', () => {
               };
 
               it('removes the error', () => {
-                expect(revalidate().find('input').props().error).to.eq(undefined);
+                expect(revalidate().find(DummyInput).props().error).to.eq(undefined);
               });
 
               it('does not call onChange', () => {
@@ -461,7 +463,7 @@ describe('combinations', () => {
             };
 
             it('has an error', () => {
-              expect(invalidate().find('input').props().error).to.eq('suddenly invalid');
+              expect(invalidate().find(DummyInput).props().error).to.eq('suddenly invalid');
             });
 
             it('does not call onChange', () => {

--- a/test/form-test.js
+++ b/test/form-test.js
@@ -16,7 +16,7 @@ const validate = ({ field }) => {
 function MyForm({ fields: formFields }) {
   return (
     <div>
-      <input type="text" {...formFields.field} />
+      <input type="text" {...formFields.field.props} />
       <span>{formFields.field.error}</span>
     </div>
   );

--- a/test/resetFormButton-test.js
+++ b/test/resetFormButton-test.js
@@ -12,7 +12,7 @@ describe('ResetFormButton', () => {
 
   beforeEach(() => {
     props = {
-      foo: 'bar',
+      value: 'bar',
     };
     context = { form: {} };
   });


### PR DESCRIPTION
Related to https://gist.github.com/jimfb/d99e0678e9da715ccf6454961ef04d1b.

This allows you to use 
```jsx
<input {...this.props.fields.fieldName.props} />
``` 
instead of 
```jsx
<input {...this.props.fields.fieldName} />
``` 
which causes warnings in the current version of react.