### PR TITLE
Support react@16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "webpack": "^1.13.1"
   },
   "peerDependencies": {
-    "react": "^0.14.7 || ^15.0.0"
+    "react": "^0.14.7 || ^15.0.0 || ^16.0.0"
   },
   "dependencies": {
     "prop-types": "^15.6.0"

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
   },
   "peerDependencies": {
     "react": "^0.14.7 || ^15.0.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.0"
   }
 }

--- a/src/disabledFormSubmit.js
+++ b/src/disabledFormSubmit.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React from 'react';
 
 export default function DisabledFormSubmit(props, context) {
   return (

--- a/src/feedbackFormSubmit.js
+++ b/src/feedbackFormSubmit.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class FeedbackFormSubmit extends Component {
   static propTypes = {

--- a/src/form.js
+++ b/src/form.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 import getValue from './getValue';
 

--- a/src/resetFormButton.js
+++ b/src/resetFormButton.js
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes } from 'react';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
 
 export default class ResetFormButton extends Component {
   static propTypes = {


### PR DESCRIPTION
Hello @theadam,

I have added support of usage the lib with `react@16.0.0` targets. Review the changes, please.

I've also upgraded some development dependencies to run with `react@16.0.0` in [`feature/react-16-dev`](https://github.com/Oopscurity/react-inform/tree/feature/react-16-dev). Tests are powered with updated `enzyme` and they pass successfully. If you'd like to upgrade them too, drop me a line - I'll update the PR.

Besides, should I target the examples to `react@16.0.0` here?

Fixes #30.